### PR TITLE
Fixing problem with credentials from a slave node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>ease-plugin</artifactId>
     <!-- Name that displays on the 'Manage Plugins' page of Jenkins. -->
     <name>Arxan MAM Publisher</name>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins.io/display/JENKINS/Arxan+MAM+Publisher</url>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>ease-plugin</artifactId>
     <!-- Name that displays on the 'Manage Plugins' page of Jenkins. -->
     <name>Arxan MAM Publisher</name>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins.io/display/JENKINS/Arxan+MAM+Publisher</url>

--- a/src/main/java/org/jenkinsci/plugins/apperian/ApperianRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/apperian/ApperianRecorder.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
 
-import com.cloudbees.plugins.credentials.CredentialsProvider;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;

--- a/src/main/java/org/jenkinsci/plugins/apperian/CredentialsManager.java
+++ b/src/main/java/org/jenkinsci/plugins/apperian/CredentialsManager.java
@@ -31,7 +31,7 @@ public class CredentialsManager {
         return apiTokens;
     }
 
-    public String getCredentialWithId(String credentialId) {
+    public static String getCredentialWithId(String credentialId) {
         List<StringCredentials> stringCredentials = fetchStringCredentials();
 
         StringCredentials credential = CredentialsMatchers.firstOrNull(stringCredentials,
@@ -43,7 +43,7 @@ public class CredentialsManager {
         return secret;
     }
 
-    private List<StringCredentials> fetchStringCredentials() {
+    private static List<StringCredentials> fetchStringCredentials() {
         return CredentialsProvider.lookupCredentials(
             StringCredentials.class,
             Jenkins.getInstance(),

--- a/src/test/java/org/jenkinsci/plugins/apperian/PublishFileCallableTest.java
+++ b/src/test/java/org/jenkinsci/plugins/apperian/PublishFileCallableTest.java
@@ -32,7 +32,7 @@ public class PublishFileCallableTest {
 
         Mockito.when(listener.getLogger()).thenReturn(null);
 
-        PublishFileCallable callable = new PublishFileCallable(APPERIAN_UPLOAD1, listener);
+        PublishFileCallable callable = new PublishFileCallable(APPERIAN_UPLOAD1, listener, "api_token_id");
 
         ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
         ObjectOutputStream objOut = new ObjectOutputStream(byteOut);

--- a/src/test/java/org/jenkinsci/plugins/apperian/UploadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/apperian/UploadTest.java
@@ -58,12 +58,9 @@ public class UploadTest {
         EasyMock.replay(listener);
 
         PublishFileCallable callable = new PublishFileCallable(upload,
-                                                               listener);
+                                                               listener,
+                                                               ApiTesting.API_TOKEN);
 
-
-        CredentialsManager credentialsManagerMock = Mockito.mock(CredentialsManager.class);
-        Mockito.when(credentialsManagerMock.getCredentialWithId(FOO_API_KEY_ID)).thenReturn(ApiTesting.API_TOKEN);
-        callable.setCredentialsManager(credentialsManagerMock);
         Assert.assertTrue("Upload Failed!", callable.invoke(appBinary, null));
     }
 }


### PR DESCRIPTION
This fixes a bug where a job running on a slave node would be unable to use the plugin because it would fail to get the required credentials.
