### PR TITLE
Addressing SECURITY-2711: the plugin does not perform permission checks in several form validation methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,19 @@
 
     <developers>
         <developer>
-            <id>oleksiyp</id>
-            <name>Oleksiy Pylypenko</name>
-            <email>oleksiy.pylypenko@gmail.com</email>
+            <id>jrodriguez</id>
+            <name>Javier Rodriguez</name>
+            <email>javier.rodriguez@digital.ai</email>
         </developer>
         <developer>
-            <id>kwilson6744</id>
-            <name>Kevin Wilson</name>
-            <email>kwilson@apperian.com</email>
+            <id>puri</id>
+            <name>Puri Garcia</name>
+            <email>puri.garcia@digital.ai</email>
+        </developer>
+        <developer>
+            <id>matt_pelaggi</id>
+            <name>Matt Pelaggi</name>
+            <email>matt.pelaggi@digital.ai</email>
         </developer>
     </developers>
 

--- a/src/main/java/org/jenkinsci/plugins/apperian/CredentialsManager.java
+++ b/src/main/java/org/jenkinsci/plugins/apperian/CredentialsManager.java
@@ -8,6 +8,10 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 
 import hudson.model.Run;
+import hudson.model.Item;
+import hudson.model.Queue;
+import hudson.model.queue.Tasks;
+import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import hudson.security.ACL;
@@ -15,8 +19,8 @@ import jenkins.model.Jenkins;
 
 public class CredentialsManager {
 
-    public static String getCredentialWithId(String credentialId) {
-        List<StringCredentials> stringCredentials = fetchStringCredentials();
+    public static String getCredentialWithId(String credentialId, Item job) {
+        List<StringCredentials> stringCredentials = fetchStringCredentials(job);
 
         StringCredentials credential = CredentialsMatchers.firstOrNull(stringCredentials,
                                                                        CredentialsMatchers.withId(credentialId));
@@ -40,11 +44,25 @@ public class CredentialsManager {
         return secret;
     }
 
-    private static List<StringCredentials> fetchStringCredentials() {
+    private static List<StringCredentials> fetchStringCredentials(Item job) {
+        Authentication authentication = ACL.SYSTEM;
+        if (job instanceof Queue.Task) {
+            authentication = Tasks.getAuthenticationOf((Queue.Task)job);
+        }
+
+        if (job == null) {
+            return CredentialsProvider.lookupCredentials(
+                StringCredentials.class,
+                Jenkins.getInstance(),
+                authentication,
+                Collections.<DomainRequirement>emptyList()
+            );
+        }
+
         return CredentialsProvider.lookupCredentials(
             StringCredentials.class,
-            Jenkins.getInstance(),
-            ACL.SYSTEM,
+            job,
+            authentication,
             Collections.<DomainRequirement>emptyList()
         );
     }

--- a/src/main/resources/org/jenkinsci/plugins/apperian/ApperianUpload/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/apperian/ApperianUpload/config.jelly
@@ -18,7 +18,7 @@
                    top of the 'Add' text.  A fix has been merged into their master branch (JENKINS-52936), but is not
                    yet in their latest release (2.1.18).  We should update to 2.1.19 when possible to address the
                    issue.-->
-        <c:select />
+        <c:select checkMethod="post" />
     </f:entry>
     <f:validateButton
         title="${%Test connection}" progress="${%Testing...}"


### PR DESCRIPTION
Addressing [SECURITY-2711](https://issues.jenkins.io/browse/SECURITY-2911) (the plugin does not perform permission checks in several form validation methods). We also now enforce POST method is the method used for those endpoints.

It also updates the developers list.

### Testing done

Manual testing
- Plugin can be used to upload, apply policies and resign with an admin user from a freestyle job
- Plugin can be used to upload, apply policies and resign with an admin user from a pipeline
- Plugin can be used to upload, apply policies and resign with a user that can see the job but is not an admin from a freestyle job
- Plugin can be used to upload, apply policies and resign with a user that can see the job but is not an admin from a pipeline
- fillAppIdItems endpoint does not send the credentials to the server when it is being executed with a user that is not an admin (https://issues.jenkins.io/browse/SECURITY-2911)
- fillCredentialItems endpoint does not send the credentials to the server when it is being executed with a user that is not an admin (https://issues.jenkins.io/browse/SECURITY-2911)
- testConnection endpoint does not send the credentials to the server when it is being executed with a user that is not an admin (https://issues.jenkins.io/browse/SECURITY-2911)
